### PR TITLE
Save processing trades

### DIFF
--- a/src/trade.js
+++ b/src/trade.js
@@ -145,6 +145,7 @@ class Trade extends Exchange.Trade {
       // expecting payment for:
       return [
         'awaiting_transfer_in',
+        'processing',
         'completed',
         'completed_test'
       ].indexOf(trade.state) > -1;

--- a/src/trade.js
+++ b/src/trade.js
@@ -63,7 +63,7 @@ class Trade extends Exchange.Trade {
     this._createdAt = new Date(obj.created_at);
 
     if (this._outCurrency === 'BTC') {
-      this._txHash = obj.blockchain_tx_hash;
+      this._txHash = obj.blockchain_tx_hash || this._txHash;
       this._receiveAddress = obj.address;
     }
   }


### PR DESCRIPTION
* Need to save processing trades so that we know to watch them for incoming txs
* Don't overwrite the _txHash received from metadata, otherwise modal will show more than just the first time a tx is found