### PR TITLE
Trade txHash assignment

### DIFF
--- a/src/trade.js
+++ b/src/trade.js
@@ -66,7 +66,7 @@ class Trade extends Exchange.Trade {
     }
 
     this._receiveAddress = obj.address;
-    this._txHash = obj.blockchain_tx_hash || this._txHash;
+    this._txHash = obj.blockchain_tx_hash || (!this._is_buy ? this._txHash : null);
   }
 
   setFromJSON (obj) {


### PR DESCRIPTION
Proposed change to assign Trade txHash property to `this._txHash` only if it's a sell trade _and_ `obj.blockchain_tx_hash` isn't available. 